### PR TITLE
Update team member section to include links to GitHub profiles

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -90,20 +90,29 @@
 
                 <div class="team-container">
                     <div class="team-member">
-                        <img src="/images/ramsey.png" alt="Ramsey" />
-                        <h3>Ramsey</h3>
-                        <p>Founder & Lead Developer</p>
+                        <a href="https://github.com/ramseyediku"
+                            ><img src="../images/ramsey.png" alt="Ramsey" />
+                            <h3>Ramsey</h3>
+                            <p>Founder & Lead Developer</p></a
+                        >
                     </div>
                     <div class="team-member">
-                        <img src="/images/helder.jpeg" alt="Helder Balbino" />
-                        <h3>Helder Balbino</h3>
-                        <p>Founder & Lead Developer</p>
+                        <a href="https://github.com/HelderBalbino">
+                            <img
+                                src="../images/helder.jpeg"
+                                alt="Helder Balbino"
+                            />
+                            <h3>Helder Balbino</h3>
+                            <p>Founder & Lead Developer</p>
+                        </a>
                     </div>
 
                     <div class="team-member">
-                        <img src="/images/matt.jpeg" alt="Matt" />
-                        <h3>Matt</h3>
-                        <p>Founder & Lead Developer</p>
+                        <a href="https://github.com/matthewyoung94">
+                            <img src="../images/matt.jpeg" alt="Matt" />
+                            <h3>Matt</h3>
+                            <p>Founder & Lead Developer</p>
+                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This pull request includes changes to the `about/index.html` file to add links to the GitHub profiles of team members. The changes wrap the images and text of each team member in an anchor tag that links to their respective GitHub profiles.

Changes to `about/index.html`:

* Added anchor tags around the images and text of team members to link to their GitHub profiles.